### PR TITLE
feat: add chip-based format builder

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,14 +1,11 @@
 import React, { useState, useMemo } from 'react';
 import LogDisplay from './components/LogDisplay';
-import { DEFAULT_FORMAT, SYNTHETIC_LOG_DATA } from './constants';
+import FormatBuilder from './components/FormatBuilder';
+import { SYNTHETIC_LOG_DATA } from './constants';
 import { formatGitLog } from './services/gitFormatter';
 
 const App: React.FC = () => {
-  const [formatString, setFormatString] = useState<string>(DEFAULT_FORMAT);
-
-  const handleFormatChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setFormatString(event.target.value);
-  };
+  const [formatString, setFormatString] = useState<string>('');
 
   const formattedLines = useMemo(() => {
     if (!formatString.trim()) {
@@ -34,23 +31,23 @@ const App: React.FC = () => {
       </header>
 
       <main className="w-full max-w-4xl">
+        <FormatBuilder onChange={setFormatString} />
         <div className="flex flex-col">
-          <label htmlFor="format-input" className="mb-2 text-sm font-medium text-slate-400">
-            Enter your format string:
+          <label htmlFor="format-output" className="mb-2 text-sm font-medium text-slate-400">
+            Current format string:
           </label>
           <textarea
-            id="format-input"
+            id="format-output"
             value={formatString}
-            onChange={handleFormatChange}
-            className="w-full h-28 p-3 bg-slate-800 border border-slate-700 rounded-lg text-slate-200 font-mono text-sm focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition-shadow duration-200"
-            placeholder="e.g., %h - %s"
+            readOnly
+            className="w-full h-28 p-3 bg-slate-800 border border-slate-700 rounded-lg text-slate-200 font-mono text-sm"
             spellCheck="false"
           />
         </div>
-        
+
         <LogDisplay lines={formattedLines} />
       </main>
-      
+
       <footer className="mt-12 text-center text-slate-500 text-sm">
         <p>Common placeholders: %h, %H, %s, %an, %ar, %d, %n, %C(yellow), %C(reset)</p>
         <p>&copy; {new Date().getFullYear()} - Built for demonstration.</p>

--- a/components/FormatBuilder.tsx
+++ b/components/FormatBuilder.tsx
@@ -2,19 +2,97 @@ import React, { useState, useEffect } from 'react';
 import { FormatChip } from '../types';
 import { chipsToFormatString } from '../services/chipFormatter';
 
-const ELEMENT_CHIPS: FormatChip[] = [
-  { id: 'h', label: '%h', value: '%h', group: 'element' },
-  { id: 'H', label: '%H', value: '%H', group: 'element' },
-  { id: 's', label: '%s', value: '%s', group: 'element' },
-  { id: 'an', label: '%an', value: '%an', group: 'element' },
-  { id: 'ar', label: '%ar', value: '%ar', group: 'element' },
-  { id: 'd', label: '%d', value: '%d', group: 'element' },
+interface ChipGroup {
+  title: string;
+  chips: FormatChip[];
+}
+
+const ELEMENT_GROUPS: ChipGroup[] = [
+  {
+    title: 'Commit Hash',
+    chips: [
+      { id: 'H', label: 'Hash: full', value: '%H' },
+      { id: 'h', label: 'Hash: short', value: '%h' },
+    ],
+  },
+  {
+    title: 'Tree Hash',
+    chips: [
+      { id: 'T', label: 'Tree hash: full', value: '%T' },
+      { id: 't', label: 'Tree hash: short', value: '%t' },
+    ],
+  },
+  {
+    title: 'Parent Hashes',
+    chips: [
+      { id: 'P', label: 'Parent hashes: full', value: '%P' },
+      { id: 'p', label: 'Parent hashes: short', value: '%p' },
+    ],
+  },
+  {
+    title: 'Author',
+    chips: [
+      { id: 'an', label: 'Author name', value: '%an' },
+      { id: 'ae', label: 'Author email', value: '%ae' },
+      { id: 'al', label: 'Author local-part', value: '%al' },
+      { id: 'ad', label: 'Author date', value: '%ad' },
+      { id: 'ai', label: 'Author date ISO-like', value: '%ai' },
+      { id: 'aI', label: 'Author date strict ISO', value: '%aI' },
+      { id: 'ah', label: 'Author date human', value: '%ah' },
+      { id: 'as', label: 'Author date short', value: '%as' },
+      { id: 'at', label: 'Author date UNIX', value: '%at' },
+      { id: 'ar', label: 'Author date relative', value: '%ar' },
+    ],
+  },
+  {
+    title: 'Committer',
+    chips: [
+      { id: 'cn', label: 'Committer name', value: '%cn' },
+      { id: 'ce', label: 'Committer email', value: '%ce' },
+      { id: 'cl', label: 'Committer local-part', value: '%cl' },
+      { id: 'cd', label: 'Committer date', value: '%cd' },
+      { id: 'ci', label: 'Committer date ISO-like', value: '%ci' },
+      { id: 'cI', label: 'Committer date strict ISO', value: '%cI' },
+      { id: 'ch', label: 'Committer date human', value: '%ch' },
+      { id: 'cs', label: 'Committer date short', value: '%cs' },
+      { id: 'ct', label: 'Committer date UNIX', value: '%ct' },
+      { id: 'cr', label: 'Committer date relative', value: '%cr' },
+    ],
+  },
+  {
+    title: 'Subject & Body',
+    chips: [
+      { id: 's', label: 'Subject', value: '%s' },
+      { id: 'f', label: 'Subject sanitized', value: '%f' },
+      { id: 'b', label: 'Body', value: '%b' },
+      { id: 'B', label: 'Subject and body', value: '%B' },
+    ],
+  },
+  {
+    title: 'Refs',
+    chips: [
+      { id: 'd', label: 'Decorations', value: '%d' },
+      { id: 'D', label: 'Decorations (plain)', value: '%D' },
+    ],
+  },
+  {
+    title: 'Misc',
+    chips: [
+      { id: 'e', label: 'Encoding', value: '%e' },
+      { id: 'n', label: 'Newline', value: '%n' },
+    ],
+  },
 ];
 
-const STYLE_CHIPS: FormatChip[] = [
-  { id: 'C-yellow', label: '%C(yellow)', value: '%C(yellow)', group: 'style' },
-  { id: 'C-green', label: '%C(green)', value: '%C(green)', group: 'style' },
-  { id: 'C-reset', label: '%C(reset)', value: '%C(reset)', group: 'style' },
+const STYLE_GROUPS: ChipGroup[] = [
+  {
+    title: 'Colors',
+    chips: [
+      { id: 'C-yellow', label: 'Color: yellow', value: '%C(yellow)' },
+      { id: 'C-green', label: 'Color: green', value: '%C(green)' },
+      { id: 'C-reset', label: 'Reset color', value: '%C(reset)' },
+    ],
+  },
 ];
 
 interface FormatBuilderProps {
@@ -48,31 +126,41 @@ const FormatBuilder: React.FC<FormatBuilderProps> = ({ onChange }) => {
           ))}
         </div>
       </div>
-      <div className="w-48 ml-4">
+      <div className="w-64 ml-4 overflow-y-auto max-h-96">
         <h3 className="text-slate-400 text-xs mb-1">Elements</h3>
-        <div className="flex flex-wrap gap-2 mb-4">
-          {ELEMENT_CHIPS.map(chip => (
-            <button
-              key={chip.id}
-              onClick={() => addChip(chip)}
-              className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-xs"
-            >
-              {chip.label}
-            </button>
-          ))}
-        </div>
+        {ELEMENT_GROUPS.map(group => (
+          <div key={group.title} className="mb-4">
+            <h4 className="text-slate-500 text-[10px] mb-1 uppercase tracking-wide">{group.title}</h4>
+            <div className="flex flex-wrap gap-2">
+              {group.chips.map(chip => (
+                <button
+                  key={chip.id}
+                  onClick={() => addChip(chip)}
+                  className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-xs"
+                >
+                  {chip.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
         <h3 className="text-slate-400 text-xs mb-1">Styles</h3>
-        <div className="flex flex-wrap gap-2">
-          {STYLE_CHIPS.map(chip => (
-            <button
-              key={chip.id}
-              onClick={() => addChip(chip)}
-              className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-xs"
-            >
-              {chip.label}
-            </button>
-          ))}
-        </div>
+        {STYLE_GROUPS.map(group => (
+          <div key={group.title} className="mb-4">
+            <h4 className="text-slate-500 text-[10px] mb-1 uppercase tracking-wide">{group.title}</h4>
+            <div className="flex flex-wrap gap-2">
+              {group.chips.map(chip => (
+                <button
+                  key={chip.id}
+                  onClick={() => addChip(chip)}
+                  className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-xs"
+                >
+                  {chip.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/components/FormatBuilder.tsx
+++ b/components/FormatBuilder.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from 'react';
+import { FormatChip } from '../types';
+import { chipsToFormatString } from '../services/chipFormatter';
+
+const ELEMENT_CHIPS: FormatChip[] = [
+  { id: 'h', label: '%h', value: '%h', group: 'element' },
+  { id: 'H', label: '%H', value: '%H', group: 'element' },
+  { id: 's', label: '%s', value: '%s', group: 'element' },
+  { id: 'an', label: '%an', value: '%an', group: 'element' },
+  { id: 'ar', label: '%ar', value: '%ar', group: 'element' },
+  { id: 'd', label: '%d', value: '%d', group: 'element' },
+];
+
+const STYLE_CHIPS: FormatChip[] = [
+  { id: 'C-yellow', label: '%C(yellow)', value: '%C(yellow)', group: 'style' },
+  { id: 'C-green', label: '%C(green)', value: '%C(green)', group: 'style' },
+  { id: 'C-reset', label: '%C(reset)', value: '%C(reset)', group: 'style' },
+];
+
+interface FormatBuilderProps {
+  onChange: (format: string) => void;
+}
+
+const FormatBuilder: React.FC<FormatBuilderProps> = ({ onChange }) => {
+  const [chips, setChips] = useState<FormatChip[]>([]);
+
+  useEffect(() => {
+    onChange(chipsToFormatString(chips));
+  }, [chips, onChange]);
+
+  const addChip = (chip: FormatChip) => setChips(prev => [...prev, chip]);
+  const removeChip = (index: number) => {
+    setChips(prev => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="flex mb-4">
+      <div className="flex-1">
+        <div className="flex flex-wrap gap-2 p-2 bg-slate-800 border border-slate-700 rounded">
+          {chips.map((chip, idx) => (
+            <button
+              key={idx}
+              onClick={() => removeChip(idx)}
+              className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-sm"
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="w-48 ml-4">
+        <h3 className="text-slate-400 text-xs mb-1">Elements</h3>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {ELEMENT_CHIPS.map(chip => (
+            <button
+              key={chip.id}
+              onClick={() => addChip(chip)}
+              className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-xs"
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+        <h3 className="text-slate-400 text-xs mb-1">Styles</h3>
+        <div className="flex flex-wrap gap-2">
+          {STYLE_CHIPS.map(chip => (
+            <button
+              key={chip.id}
+              onClick={() => addChip(chip)}
+              className="bg-slate-700 text-slate-200 px-2 py-1 rounded text-xs"
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FormatBuilder;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "rm -rf dist && tsc tests/gitFormatter.test.ts services/gitFormatter.ts types.ts --outDir dist --module es2022 --target ES2022 --esModuleInterop --moduleResolution bundler --skipLibCheck && node dist/tests/gitFormatter.test.js"
+    "test": "rm -rf dist && tsc tests/gitFormatter.test.ts tests/chipFormatter.test.ts services/gitFormatter.ts services/chipFormatter.ts types.ts --outDir dist --module es2022 --target ES2022 --esModuleInterop --moduleResolution bundler --skipLibCheck && node dist/tests/gitFormatter.test.js && node dist/tests/chipFormatter.test.js"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/plans/visual-chips-plan.md
+++ b/plans/visual-chips-plan.md
@@ -1,0 +1,20 @@
+# Visual Chips Interface Plan
+
+This document tracks the addition of a chip-based interface for building the pretty
+format string. Chips represent either formatting elements (e.g. `%h`, `%s`) or
+stylistic directives (e.g. `%C(yellow)`). The user assembles chips to create the
+format string which is displayed in a read-only textarea.
+
+## Tasks
+- [x] Create a `FormatBuilder` component that manages an ordered list of chips
+      and exposes the resulting format string via a callback.
+- [x] Display selected chips above the format string textarea; chips can be
+      removed by clicking on them.
+- [x] Render a palette of available chips on the right side of the screen,
+      grouped into "Elements" and "Styles"; clicking a palette chip adds it to
+      the selected list.
+- [x] Update `App.tsx` to use `FormatBuilder` and make the textarea read-only,
+      sourcing its value from the builder.
+- [x] Provide a small helper function to convert a chip sequence to a format
+      string and test it with Node's `test` runner.
+- [x] Ensure existing tests continue to pass.

--- a/plans/visual-chips-plan.md
+++ b/plans/visual-chips-plan.md
@@ -18,3 +18,6 @@ format string which is displayed in a read-only textarea.
 - [x] Provide a small helper function to convert a chip sequence to a format
       string and test it with Node's `test` runner.
 - [x] Ensure existing tests continue to pass.
+- [x] Replace placeholder labels with human-readable names.
+- [x] Expand chip palette to include all supported format elements grouped by type.
+- [x] Remove the unused `group` field from `FormatChip` and update tests.

--- a/services/chipFormatter.ts
+++ b/services/chipFormatter.ts
@@ -1,0 +1,5 @@
+import { FormatChip } from '../types';
+
+export const chipsToFormatString = (chips: FormatChip[]): string => {
+  return chips.map(chip => chip.value).join('');
+};

--- a/tests/chipFormatter.test.ts
+++ b/tests/chipFormatter.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+// @ts-ignore
+import { chipsToFormatString } from '../services/chipFormatter.js';
+// @ts-ignore
+import { FormatChip } from '../types.js';
+
+test('converts chips to format string', () => {
+  const chips: FormatChip[] = [
+    { id: 'h', label: '%h', value: '%h', group: 'element' },
+    { id: 'C-yellow', label: '%C(yellow)', value: '%C(yellow)', group: 'style' },
+    { id: 's', label: '%s', value: '%s', group: 'element' },
+  ];
+  assert.equal(chipsToFormatString(chips), '%h%C(yellow)%s');
+});

--- a/tests/chipFormatter.test.ts
+++ b/tests/chipFormatter.test.ts
@@ -7,9 +7,9 @@ import { FormatChip } from '../types.js';
 
 test('converts chips to format string', () => {
   const chips: FormatChip[] = [
-    { id: 'h', label: '%h', value: '%h', group: 'element' },
-    { id: 'C-yellow', label: '%C(yellow)', value: '%C(yellow)', group: 'style' },
-    { id: 's', label: '%s', value: '%s', group: 'element' },
+    { id: 'h', label: 'Hash: short', value: '%h' },
+    { id: 'C-yellow', label: 'Color: yellow', value: '%C(yellow)' },
+    { id: 's', label: 'Subject', value: '%s' },
   ];
   assert.equal(chipsToFormatString(chips), '%h%C(yellow)%s');
 });

--- a/types.ts
+++ b/types.ts
@@ -18,3 +18,10 @@ export interface GitCommit {
   refs: string;
   encoding?: string;
 }
+
+export interface FormatChip {
+  id: string;
+  label: string;
+  value: string;
+  group: 'element' | 'style';
+}

--- a/types.ts
+++ b/types.ts
@@ -23,5 +23,4 @@ export interface FormatChip {
   id: string;
   label: string;
   value: string;
-  group: 'element' | 'style';
 }


### PR DESCRIPTION
## Summary
- introduce `FormatBuilder` with selectable chips for elements and styles
- display chip selections above the format string and update `App` to show read-only result
- add helper and tests for chip-to-string formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc6f31c5f48325a0558240358d21a3