### PR TITLE
feat: expand color styling options

### DIFF
--- a/components/FormatBuilder.tsx
+++ b/components/FormatBuilder.tsx
@@ -88,8 +88,16 @@ const STYLE_GROUPS: ChipGroup[] = [
   {
     title: 'Colors',
     chips: [
-      { id: 'C-yellow', label: 'Color: yellow', value: '%C(yellow)' },
+      { id: 'C-normal', label: 'Color: normal', value: '%C(normal)' },
+      { id: 'C-black', label: 'Color: black', value: '%C(black)' },
+      { id: 'C-red', label: 'Color: red', value: '%C(red)' },
       { id: 'C-green', label: 'Color: green', value: '%C(green)' },
+      { id: 'C-yellow', label: 'Color: yellow', value: '%C(yellow)' },
+      { id: 'C-blue', label: 'Color: blue', value: '%C(blue)' },
+      { id: 'C-magenta', label: 'Color: magenta', value: '%C(magenta)' },
+      { id: 'C-cyan', label: 'Color: cyan', value: '%C(cyan)' },
+      { id: 'C-white', label: 'Color: white', value: '%C(white)' },
+      { id: 'C-default', label: 'Color: default', value: '%C(default)' },
       { id: 'C-reset', label: 'Reset color', value: '%C(reset)' },
     ],
   },

--- a/components/LogDisplay.tsx
+++ b/components/LogDisplay.tsx
@@ -9,6 +9,7 @@ interface LogDisplayProps {
 const COLOR_MAP: { [key: string]: string } = {
   normal: '',
   reset: '',
+  default: '',
   black: 'text-slate-500',
   red: 'text-red-500',
   green: 'text-green-500',

--- a/plans/plan.md
+++ b/plans/plan.md
@@ -24,6 +24,7 @@ same semantics as `git log --pretty=format:"..."`.
 - `%cl` / `%cL` – committer email local-part
 - `%ci` / `%cI` / `%ch` – committer date ISO-like / strict ISO / human
 - Message/body fields: `%f`, `%b`, `%B`, `%e`
+- Color directives: `%C(<color>)`, `%C(reset)` (normal, black, red, green, yellow, blue, magenta, cyan, white, default)
 
 ## Planned Additions
 The reference (`reference/git_pretty_reference.html`) documents many more
@@ -35,7 +36,7 @@ These placeholders exist in the reference but are not yet handled:
 - Decoration fields: `%gD`, `%gN`, `%g*` (Note: requires reflog data)
 - GPG/signature fields: `%G*`, `%GF`, `%GG`, `%GP`, `%GS`, `%GT`
 - Notes and refs: `%N`, `%S`
-- Formatting helpers: `%C(color)`, `%Creset`, `%m`, `%w(...)`, `%xNN` for hex
+- Formatting helpers: `%m`, `%w(...)`, `%xNN` for hex
 
 These items remain TODO and should be implemented or explicitly scoped out in
 future iterations.


### PR DESCRIPTION
## Summary
- expand FormatBuilder color chip options to include normal, black, red, green, yellow, blue, magenta, cyan, white and default
- support `%C(default)` in LogDisplay color map
- document color directive support in project plan

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca193491c8325854885be1c4def83