### PR TITLE
feat: add text chip for custom literals

### DIFF
--- a/components/SelectComponents.tsx
+++ b/components/SelectComponents.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormatChip } from '../types';
 import SplitChip from './SplitChip';
 import StyleChip from './StyleChip';
+import TextChip from './TextChip';
 import { ELEMENT_CHIP_GROUPS, STYLE_CHIPS } from '../constants';
 
 interface SelectComponentsProps {
@@ -26,6 +27,7 @@ const SelectComponents: React.FC<SelectComponentsProps> = ({ onSelect }) => {
             chips={STYLE_CHIPS.chips}
             onSelect={onSelect}
           />
+          <TextChip onSelect={onSelect} />
         </div>
       </div>
     </div>

--- a/components/TextChip.tsx
+++ b/components/TextChip.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { nanoid } from 'nanoid';
+import { FormatChip } from '../types';
+
+interface TextChipProps {
+  onSelect: (chip: FormatChip) => void;
+}
+
+const TextChip: React.FC<TextChipProps> = ({ onSelect }) => {
+  const handleClick = () => {
+    const text = window.prompt('Enter text to insert');
+    if (text !== null && text !== '') {
+      onSelect({ id: `text-${nanoid()}`, label: text, value: text });
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="px-3 py-1 rounded-md border border-slate-600 bg-slate-700 text-sm font-medium text-slate-200 hover:bg-slate-600"
+    >
+      Text
+    </button>
+  );
+};
+
+export default TextChip;

--- a/plans/text-chip-plan.md
+++ b/plans/text-chip-plan.md
@@ -1,0 +1,10 @@
+# Text Chip Plan
+
+This document tracks the addition of a `Text` component chip that lets users insert literal text into the format builder.
+
+## Tasks
+- [x] Outline approach for text chip and create plan.
+- [x] Implement `TextChip` component prompting for input and creating chip.
+- [x] Add `TextChip` to the component selection area.
+- [x] Update formatter tests to cover text chips.
+- [x] Verify all tests pass.

--- a/tests/chipFormatter.test.ts
+++ b/tests/chipFormatter.test.ts
@@ -13,3 +13,11 @@ test('converts chips to format string', () => {
   ];
   assert.equal(chipsToFormatString(chips), '%h%C(yellow)%s');
 });
+
+test('includes plain text chips', () => {
+  const chips: FormatChip[] = [
+    { id: 'text-1', label: 'hello', value: 'hello' },
+    { id: 'h', label: 'Hash: short', value: '%h' },
+  ];
+  assert.equal(chipsToFormatString(chips), 'hello%h');
+});


### PR DESCRIPTION
## Summary
- add `TextChip` component that prompts users for characters and inserts them as chips
- expose `Text` chip in selection menu for formatting
- cover text chips in formatter tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be98dd770c8325976a16ef3b7e4136