### PR TITLE
feat: add light and dark themes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -10,7 +10,16 @@ import { formatGitLog } from './services/gitFormatter';
 import { chipsToFormatString } from './services/chipFormatter';
 import { FormatChip } from './types';
 
-const App: React.FC = () => {
+interface AppProps {
+  defaultTheme: 'light' | 'dark';
+}
+
+const App: React.FC<AppProps> = ({ defaultTheme }) => {
+  const [theme, setTheme] = useState<'light' | 'dark'>(defaultTheme);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
   const [chips, setChips] = useState<FormatChip[]>([]);
 
   const formatString = useMemo(() => chipsToFormatString(chips), [chips]);
@@ -42,7 +51,14 @@ const App: React.FC = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="min-h-screen bg-background text-primary font-sans p-4 sm:p-8 flex flex-col items-center">
-        <header className="text-center mb-8">
+        <header className="text-center mb-8 relative">
+          <button
+            onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+            className="absolute top-0 right-0 px-3 py-1 rounded bg-surface border border-border text-primary"
+            aria-label="Toggle theme"
+          >
+            {theme === 'light' ? 'Dark' : 'Light'} Mode
+          </button>
           <h1 className="text-4xl sm:text-5xl font-bold text-accent tracking-tight">
             Git Log Pretty Format Simulator
           </h1>

--- a/index.tsx
+++ b/index.tsx
@@ -8,10 +8,12 @@ const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error("Could not find root element to mount to");
 }
+const defaultTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+document.documentElement.setAttribute('data-theme', defaultTheme);
 
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <App defaultTheme={defaultTheme} />
   </React.StrictMode>
 );

--- a/theme.css
+++ b/theme.css
@@ -1,4 +1,24 @@
 :root {
+  color-scheme: light;
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f1f5f9;
+  --color-surface-hover: #e2e8f0;
+  --color-border: #e2e8f0;
+  --color-text: #334155;
+  --color-text-secondary: #475569;
+  --color-text-muted: #64748b;
+  --color-text-light: #0f172a;
+  --color-accent: #0ea5e9;
+  --color-accent-dark: #0284c7;
+  --color-accent-darker: #0369a1;
+  --color-danger: #ef4444;
+  --color-white: #ffffff;
+  --color-black: #000000;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
   --color-bg: #0f172a;
   --color-surface: #1e293b;
   --color-surface-muted: #334155;


### PR DESCRIPTION
## Summary
- add light and dark color palettes
- default to system theme with toggle button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf21e424108325a52c10cbe89cf158